### PR TITLE
fix(sync_routes): temporarily disable m2mAuth middleware for sync cha…

### DIFF
--- a/start/routes/sync.ts
+++ b/start/routes/sync.ts
@@ -18,5 +18,5 @@ router
       .get('/sincronizar-canales', [SyncController, 'syncChannels'])
       .use(middleware.rateLimit({ max: 10, windowMs: 60_000, key: 'global' }))
   })
-  .use(middleware.m2mAuth())
+  //.use(middleware.m2mAuth())
   .prefix('api')


### PR DESCRIPTION
…nnels route

- Commented out the m2mAuth middleware in the sync channels route to allow for easier testing and debugging of synchronization processes.
- This change is intended to facilitate development and may be revisited for re-enabling in future updates.