### PR TITLE
fix(sync_webhook_notifier): update default stagger time for global fa…

### DIFF
--- a/app/services/synchronizations/sync_webhook_notifier.ts
+++ b/app/services/synchronizations/sync_webhook_notifier.ts
@@ -55,8 +55,9 @@ function timeoutMs(): number {
   return env.get('SYNC_WEBHOOK_TIMEOUT_MS') ?? DEFAULT_WEBHOOK_TIMEOUT_MS
 }
 
+/** Pausa entre canales en fan-out global (default 1 min). */
 function staggerMs(): number {
-  return env.get('SYNC_WEBHOOK_GLOBAL_STAGGER_MS') ?? 90_000
+  return env.get('SYNC_WEBHOOK_GLOBAL_STAGGER_MS') ?? 60_000
 }
 
 function retryAfterMs(): number {

--- a/start/env.ts
+++ b/start/env.ts
@@ -264,7 +264,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   SYNC_WEBHOOKS_ENABLED: Env.schema.boolean.optional(),
   /** Timeout del POST; debe cubrir lock del destino + respuesta (default en codigo ~330s si no se define) */
   SYNC_WEBHOOK_TIMEOUT_MS: Env.schema.number.optional(),
-  /** Pausa entre marcas en fan-out global; si todas pegan al mismo host y hay lock largo, usar >= lock (ej. 300s) */
+  /** Pausa entre canales en fan-out global (default en codigo 60_000 ms = 1 min) */
   SYNC_WEBHOOK_GLOBAL_STAGGER_MS: Env.schema.number.optional(),
   /** Entre reintentos tras fallo (409, timeout, etc.); alinear con lock del storefront (ej. bigcommerceSyncLock:300 -> 300000) */
   SYNC_WEBHOOK_RETRY_AFTER_MS: Env.schema.number.optional(),


### PR DESCRIPTION
…n-out

- Changed the default stagger time from 90 seconds to 60 seconds in the sync webhook notifier to optimize synchronization intervals.
- Updated documentation to clarify the purpose of the stagger time in the context of global fan-out.