### PR TITLE
feat(variant_format): add product_id to variant DTOs and formatters

### DIFF
--- a/app/application/dto/variant_format.dto.ts
+++ b/app/application/dto/variant_format.dto.ts
@@ -4,6 +4,7 @@
  */
 export interface VariantForFormatDTO {
   id: number
+  product_id: number
   sku: string
   normal_price?: number | string | null
   discount_price?: number | string | null

--- a/app/application/formatters/variants_by_channel_formatter.ts
+++ b/app/application/formatters/variants_by_channel_formatter.ts
@@ -12,6 +12,7 @@ export interface FormatVariantForMarcasOptions {
 /** Estructura que esperan las marcas para variantes por canal. */
 export interface VariantForMarcas {
   id: number
+  product_id: number
   sku: string
   type: 'variant'
   image: string
@@ -92,6 +93,7 @@ export function formatVariantForMarcas(
 
   const result: VariantForMarcas = {
     id: variant.id,
+    product_id: variant.product_id,
     sku: variant.sku,
     type: 'variant',
     image,

--- a/app/infrastructure/mappers/variant_format.mapper.ts
+++ b/app/infrastructure/mappers/variant_format.mapper.ts
@@ -16,6 +16,7 @@ export function toVariantForFormatDTO(variant: Variant): VariantForFormatDTO {
   }
   return {
     id: variant.id,
+    product_id: variant.product_id,
     sku: variant.sku,
     normal_price: variant.normal_price,
     discount_price: variant.discount_price,

--- a/app/infrastructure/persistence/repositories/variant_repository.ts
+++ b/app/infrastructure/persistence/repositories/variant_repository.ts
@@ -69,12 +69,11 @@ export default class VariantRepository implements VariantRepositoryPort {
     limit: number,
     parentCategoryId?: number
   ): Promise<{ data: unknown[]; meta: VariantPaginatedMeta }> {
+    // Sin filtro por is_visible: la ruta by-channel debe listar todas las variantes del canal
     const query = Variant.query()
       .join('channel_product', 'variants.product_id', 'channel_product.product_id')
       .where('channel_product.channel_id', channelId)
       .join('products', 'variants.product_id', 'products.id')
-      .where('variants.is_visible', true)
-      .where('products.is_visible', true)
       .select('variants.*')
       .preload('product')
       .orderBy('variants.id', 'asc')

--- a/app/presentation/controllers/variants/variant_controller.ts
+++ b/app/presentation/controllers/variants/variant_controller.ts
@@ -54,7 +54,8 @@ export default class VariantController {
   }
 
   /**
-   * Lista variantes por canal en formato marcas (id, sku, image, stock, main_title, precios, reserve, etc.).
+   * Lista variantes por canal en formato marcas (id, product_id, sku, image, stock, main_title, precios, reserve, etc.).
+   * Incluye variantes y productos aunque is_visible sea false (solo filtra por pertenencia al canal).
    * Query: channel_id (number) o brand (string).
    * GET /api/variants/by-channel?channel_id=1 o ?brand=UF
    */

--- a/app/presentation/validators/variants_by_channel_validator.ts
+++ b/app/presentation/validators/variants_by_channel_validator.ts
@@ -2,7 +2,8 @@ import vine from '@vinejs/vine'
 
 const DEFAULT_PAGE = 1
 const DEFAULT_LIMIT = 50
-const MAX_LIMIT = 200
+/** Sync masivo por canal: permite paginas grandes; el servidor acota memoria/timeout */
+const MAX_LIMIT = 10_000
 
 /** Query para GET /variants/by-channel: channel_id (number) o brand (string). */
 export const variantsByChannelSchema = vine.object({


### PR DESCRIPTION
- Introduced `product_id` to the `VariantForFormatDTO` and `VariantForMarcas` interfaces to enhance data structure.
- Updated the `formatVariantForMarcas` function to include `product_id` in the formatted output.
- Modified the `toVariantForFormatDTO` function to map `product_id` from the variant.
- Adjusted the `VariantRepository` to remove visibility filters for variants in the by-channel query, allowing all variants to be listed.
- Updated documentation in the `VariantController` to reflect changes in the variant listing format.