### PR TITLE
feat(bigcommerce): implement configurable HTTP timeout for BigCommerc…

### DIFF
--- a/app/infrastructure/bigcommerce/modules/products/products.ts
+++ b/app/infrastructure/bigcommerce/modules/products/products.ts
@@ -1,3 +1,4 @@
+import env from '#start/env'
 import type { Logger } from '@adonisjs/core/logger'
 import type { AxiosInstance } from 'axios'
 
@@ -106,12 +107,14 @@ export default class ProductsApi {
       let allProducts: any[] = []
       let page = params.page ? Number(params.page) : 1
 
+      const catalogPageTimeoutMs = env.get('BIGCOMMERCE_HTTP_TIMEOUT_MS') ?? 120_000
+
       while (true) {
         params.page = page
 
         const response = await this.client.get('/v3/catalog/products', {
           params,
-          timeout: 30_000,
+          timeout: catalogPageTimeoutMs,
         })
 
         const body = response.data as {

--- a/app/infrastructure/http/bigcommerce_client.ts
+++ b/app/infrastructure/http/bigcommerce_client.ts
@@ -16,9 +16,11 @@ export function getBigcommerceClient(): AxiosInstance {
     const storeHash = env.get('BIGCOMMERCE_API_STORE_ID') || ''
     const baseURL = `${env.get('BIGCOMMERCE_API_URL') || ''}${storeHash}`
 
+    const httpTimeoutMs = env.get('BIGCOMMERCE_HTTP_TIMEOUT_MS') ?? 120_000
+
     const instance = axiosCreate({
       baseURL,
-      timeout: 30_000,
+      timeout: httpTimeoutMs,
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',

--- a/app/services/n8n_alert_service.ts
+++ b/app/services/n8n_alert_service.ts
@@ -4,6 +4,24 @@ import Logger from '@adonisjs/core/services/logger'
 import type { AxiosError } from 'axios'
 
 const REFERENCE_MAX_LENGTH = 600
+const DETAILS_MAX_LENGTH = 4000
+
+function detailsForN8n(message: unknown): string {
+  if (message === undefined || message === null) {
+    return ''
+  }
+  if (typeof message === 'string') {
+    return message.length > DETAILS_MAX_LENGTH
+      ? `${message.slice(0, DETAILS_MAX_LENGTH)}…`
+      : message
+  }
+  try {
+    const s = JSON.stringify(message)
+    return s.length > DETAILS_MAX_LENGTH ? `${s.slice(0, DETAILS_MAX_LENGTH)}…` : s
+  } catch {
+    return String(message)
+  }
+}
 
 /**
  * Envía alertas operativas a n8n (errores críticos de sync).
@@ -41,7 +59,12 @@ export default class N8nAlertService {
     const referenceTrunc =
       refTrim.length > REFERENCE_MAX_LENGTH ? `${refTrim.slice(0, REFERENCE_MAX_LENGTH)}…` : refTrim
 
-    const payload = { title: titleTrim, reference: referenceTrunc, message }
+    const payload = {
+      title: titleTrim,
+      reference: referenceTrunc,
+      message,
+      details: detailsForN8n(message),
+    }
 
     try {
       const client = getN8nClient()

--- a/start/env.ts
+++ b/start/env.ts
@@ -149,6 +149,14 @@ export default await Env.create(new URL('../', import.meta.url), {
 
   /*
   |----------------------------------------------------------
+  | BigCommerce (axios): timeout por defecto del cliente y catalogo paginado.
+  | Sin definir: 120_000 ms. Subir si aparece "timeout of 30000ms exceeded" en sync.
+  |----------------------------------------------------------
+  */
+  BIGCOMMERCE_HTTP_TIMEOUT_MS: Env.schema.number.optional(),
+
+  /*
+  |----------------------------------------------------------
   | ID de la categoria raiz "Filtros" para sincronizar filters_products.
   | Si no esta definido, la sync de filtros se omite.
   |----------------------------------------------------------

--- a/start/routes/product_sync.ts
+++ b/start/routes/product_sync.ts
@@ -14,16 +14,16 @@ router
       .use(middleware.rateLimit({ max: 10, windowMs: 60_000, key: 'global' }))
     router
       .get('/productos', [SyncControllerV2, 'syncProducts'])
-      .use(middleware.rateLimit({ max: 4, windowMs: 60_000, key: 'global' }))
+      .use(middleware.rateLimit({ max: 1, windowMs: 180_000, key: 'global' }))
     router
       .get('/packs', [SyncControllerV2, 'syncPacks'])
-      .use(middleware.rateLimit({ max: 1, windowMs: 15_000, key: 'global' }))
+      .use(middleware.rateLimit({ max: 1, windowMs: 60_000, key: 'global' }))
     router
       .get('/packs-reserva', [SyncControllerV2, 'syncPacksReserve'])
-      .use(middleware.rateLimit({ max: 1, windowMs: 20_000, key: 'global' }))
+      .use(middleware.rateLimit({ max: 1, windowMs: 60_000, key: 'global' }))
     router
       .get('/stock', [SyncControllerV2, 'syncStock'])
-      .use(middleware.rateLimit({ max: 1, windowMs: 10_000, key: 'global' }))
+      .use(middleware.rateLimit({ max: 1, windowMs: 30_000, key: 'global' }))
   })
   .use(middleware.m2mAuth())
   .prefix('api/sync')

--- a/start/routes/sync.ts
+++ b/start/routes/sync.ts
@@ -7,7 +7,7 @@ router
   .group(() => {
     router
       .get('/sincronizar-productos/:channel_id', [SyncController, 'syncProducts'])
-      .use(middleware.rateLimit({ max: 4, windowMs: 60_000, key: 'global' }))
+      .use(middleware.rateLimit({ max: 1, windowMs: 240_000, key: 'global' }))
     router
       .get('/sincronizar-categorias', [SyncController, 'syncCategories'])
       .use(middleware.rateLimit({ max: 1, windowMs: 15_000, key: 'global' }))


### PR DESCRIPTION
…e API requests

- Added `BIGCOMMERCE_HTTP_TIMEOUT_MS` environment variable to configure the default timeout for BigCommerce API requests, enhancing flexibility in handling network delays.
- Updated `ProductsApi` and `bigcommerce_client` to utilize the new timeout setting instead of a hardcoded value.
- Enhanced `N8nAlertService` to include a `details` field for improved error reporting, ensuring messages do not exceed specified length limits.
- Adjusted rate limits in product synchronization routes to optimize request handling and prevent overload.