### PR TITLE
feat(sync_cleanup): implement variant deletion for temporary SKUs pos…

### DIFF
--- a/app/services/synchronizations/global_product_sync_service.ts
+++ b/app/services/synchronizations/global_product_sync_service.ts
@@ -173,6 +173,9 @@ export default class GlobalProductSyncService {
       } else {
         await this.cleanupService.run(products.map((p) => p.id))
       }
+      await this.cleanupService.deleteVariantsWithTemporarySyncSku(
+        this.collectVariantIdsFromBigCommerceProducts(products)
+      )
 
       // 7. Poblar filters_products desde categorias
       if (!options?.skipFilters) {
@@ -209,6 +212,19 @@ export default class GlobalProductSyncService {
   // ================================================================
   // PASOS DEL FLUJO
   // ================================================================
+
+  /** IDs de variante BC del catalogo persistido en este run (despues del filtro de price list si aplica). */
+  private collectVariantIdsFromBigCommerceProducts(products: BigCommerceProduct[]): Set<number> {
+    const ids = new Set<number>()
+    for (const p of products) {
+      for (const v of p.variants ?? []) {
+        if (Number.isFinite(v.id)) {
+          ids.add(v.id)
+        }
+      }
+    }
+    return ids
+  }
 
   /**
    * Fuera de Chile: mapa de precios del lote leido solo desde pricelist_variant_records

--- a/app/services/synchronizations/sync_cleanup_service.ts
+++ b/app/services/synchronizations/sync_cleanup_service.ts
@@ -4,6 +4,7 @@ import CategoryProduct from '#models/category_product'
 import ChannelProduct from '#models/channel_product'
 import FiltersProduct from '#models/filters_product'
 import Option from '#models/option'
+import PricelistVariantRecord from '#models/pricelist_variant_record'
 import Product from '#models/product'
 import ProductPack from '#models/product_pack'
 import Variant from '#models/variant'
@@ -13,6 +14,7 @@ import db from '@adonisjs/lucid/services/db'
 /**
  * Responsabilidad unica: detectar y limpiar productos descontinuados.
  * Implementa un safety threshold para evitar limpiezas masivas por error de API.
+ * Tras sync, elimina variantes _sync_* huérfanas (id no incluido en el snapshot BC del mismo run).
  */
 export default class SyncCleanupService {
   private readonly logger = Logger.child({ service: 'SyncCleanupService' })
@@ -245,5 +247,42 @@ export default class SyncCleanupService {
     }
 
     return false
+  }
+
+  /**
+   * Borra variantes con "_sync_" en sku solo si su id no esta en el snapshot BC de este sync.
+   * Limpia catalog_safe_stocks, pricelist_variant_records y products_packs antes de borrar la variante.
+   */
+  async deleteVariantsWithTemporarySyncSku(syncedVariantIds: Set<number>): Promise<void> {
+    if (syncedVariantIds.size === 0) {
+      this.logger.warn(
+        'Omitiendo borrado _sync_: snapshot sin variantes (no se asume catalogo vacio como criterio seguro)'
+      )
+      return
+    }
+
+    const excludeIds = [...syncedVariantIds]
+    const rows = await Variant.query()
+      .whereRaw('strpos(sku, ?) > 0', ['_sync_'])
+      .whereNotIn('id', excludeIds)
+      .select('id')
+
+    const ids = rows.map((r) => r.id)
+    if (ids.length === 0) {
+      return
+    }
+
+    await db.transaction(async (trx) => {
+      await CatalogSafeStock.query({ client: trx }).whereIn('variant_id', ids).delete()
+      await PricelistVariantRecord.query({ client: trx }).whereIn('variant_id', ids).delete()
+      await ProductPack.query({ client: trx }).whereIn('variant_id', ids).delete()
+      await ProductPack.query({ client: trx }).whereIn('pack_variant_id', ids).delete()
+      await Variant.query({ client: trx }).whereIn('id', ids).delete()
+    })
+
+    this.logger.info(
+      { eliminadas: ids.length, variantes_en_snapshot: excludeIds.length },
+      'Variantes _sync_ huérfanas (no en snapshot) eliminadas'
+    )
   }
 }

--- a/app/utils/release_variant_sku_conflicts.ts
+++ b/app/utils/release_variant_sku_conflicts.ts
@@ -95,7 +95,9 @@ export function assignUniqueSkusForIntraBatchDuplicates<T extends { id: number; 
  * variants.sku es UNIQUE: solo una fila puede tener ''. BC a veces envia SKU vacio en varias variantes
  * y Postgres responde Key (sku)=() already exists.
  */
-export function assignPlaceholderSkuIfEmpty<T extends { id: number; sku?: unknown }>(rows: T[]): T[] {
+export function assignPlaceholderSkuIfEmpty<T extends { id: number; sku?: unknown }>(
+  rows: T[]
+): T[] {
   const norm = (s: unknown) => (typeof s === 'string' ? s.trim() : '')
   return rows.map((row) => {
     if (norm(row.sku).length > 0) return row
@@ -111,10 +113,12 @@ export async function stashVariantRowsWithBatchPlaceholderSku(
 ): Promise<void> {
   const now = new Date()
   for (const v of toUpdate) {
-    await Variant.query({ client: trx }).where('id', v.id).update({
-      sku: `_batch_tmp_${v.id}`,
-      updated_at: now,
-    })
+    await Variant.query({ client: trx })
+      .where('id', v.id)
+      .update({
+        sku: `_batch_tmp_${v.id}`,
+        updated_at: now,
+      })
   }
 }
 


### PR DESCRIPTION
…t-sync

- Added `deleteVariantsWithTemporarySyncSku` method to `SyncCleanupService` to remove orphaned variants with temporary SKUs after synchronization.
- Introduced `collectVariantIdsFromBigCommerceProducts` method in `GlobalProductSyncService` to gather variant IDs for deletion.
- Enhanced logging to track the number of deleted variants and those present in the snapshot, improving visibility into the cleanup process.